### PR TITLE
Update Chrome extension to current manifest spec

### DIFF
--- a/background.js
+++ b/background.js
@@ -17,17 +17,19 @@ function saveToOmniFocus(task) {
   });
 }
 
-chrome.browserAction.onClicked.addListener(function (tab) {
-  chrome.tabs.executeScript(
-    tab.tabId,
-    { file: 'tabinfo.js' },
-    function (result) {
-      if (result && result.length) {
-        saveToOmniFocus(result[0]);
+chrome.action.onClicked.addListener(function (tab) {
+  chrome.scripting.executeScript(
+    {
+      target: { tabId: tab.id },
+      files: ['tabinfo.js']
+    },
+    function (results) {
+      if (results && results.length && results[0].result) {
+        saveToOmniFocus(results[0].result);
       } else {
         saveToOmniFocus({
-          name: window.getSelection().toString() || document.title,
-          note: window.location.toString()
+          name: tab.title,
+          note: tab.url
         });
       }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,8 @@
 {
   "background": {
-    "persistent": false,
-    "scripts": [
-      "background.js"
-    ]
+    "service_worker": "background.js"
   },
-  "browser_action": {
+  "action": {
     "default_icon": "browser-action.png",
     "default_title": "Save tab to OmniFocus"
   },
@@ -14,11 +11,12 @@
     "16": "icon16.png",
     "128": "icon128.png"
   },
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Save to OmniFocus",
   "permissions": [
     "activeTab",
-    "contextMenus"
+    "contextMenus",
+    "scripting"
   ],
-  "version": "1.0.2"
+  "version": "1.0.3"
 }


### PR DESCRIPTION
- Update manifest_version from 2 to 3
- Change background.scripts to background.service_worker
- Replace browser_action with action API
- Update chrome.browserAction to chrome.action
- Migrate chrome.tabs.executeScript to chrome.scripting.executeScript
- Add scripting permission required for Manifest V3
- Bump version to 1.0.3
- Fix fallback logic to use tab properties instead of undefined window/document

These changes are required for Chrome Web Store compliance as Manifest V2 is deprecated and extensions must use Manifest V3.